### PR TITLE
Removes a rendundant pair of parentheses from the lambda calculus bonus answers.

### DIFF
--- a/resources/lambda-calculus-bonus-exercises-answers.md
+++ b/resources/lambda-calculus-bonus-exercises-answers.md
@@ -10,7 +10,7 @@ _Borrowed from [CSE340](https://www.youtube.com/watch?v=KoIdCHDbpMI) at Arizona 
 `(λx. ((x z)(λy. (x y))))`
 
 2. `(λx. x z) λy. w λw. w y z x`  
-`((λx. (x z))(λy. (w (λw. ((((w y) z) x))))))`
+`((λx. (x z))(λy. (w (λw. (((w y) z) x)))))`
 
 3. `λx. x y λx. y x`  
 `(λx. ((x y)(λx. (y x))))`


### PR DESCRIPTION
Thank you very much for the bonus material. It is helping me a lot.

I hope this PR is useful and not solely an annoyance.

It's quite possible that I'm overlooking something, but it appears that there are an extra set of parentheses in one of the solutions.

The official answer is:
```
((λx. (x z))(λy. (w (λw. ((((w y) z) x))))))
```
If I add digits underneath the parens to show which right pairs with which left, I get:
```
((λx. (x z))(λy. (w (λw. ((((w y) z) x))))))
                         4321   1  2  34    
```
Since I don't see anything between left paren 4 and left paren 3 or right paren 3 and right paren 4, I think that means one of the pairs can be removed.